### PR TITLE
Add Linux AppImage support and improve launch behavior

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,10 @@ on:
       - '*'
 
 jobs:
-  build:
+  build-windows:
     permissions:
       contents: write
-    name: Build and release
+    name: Build and release Windows
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -27,6 +27,29 @@ jobs:
       - run: npm run make:prod-appx
       - uses: softprops/action-gh-release@v3
         with:
+          fail_on_unmatched_files: false
           files: |
             dist/executables/*.exe
             dist/executables/*.appx
+
+  build-linux:
+    permissions:
+      contents: write
+    name: Build and release Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24.14.0"
+          cache: 'npm'
+      - run: npm ci --prefer-offline --no-audit --ignore-scripts
+      - run: npm run build:all
+      - run: npm run make:prod-appimage
+      - uses: softprops/action-gh-release@v3
+        with:
+          fail_on_unmatched_files: false
+          files: |
+            dist/executables/*.AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,6 @@ jobs:
       - run: npm run make:prod-appx
       - uses: softprops/action-gh-release@v3
         with:
-          fail_on_unmatched_files: false
           files: |
             dist/executables/*.exe
             dist/executables/*.appx
@@ -50,6 +49,5 @@ jobs:
       - run: npm run make:prod-appimage
       - uses: softprops/action-gh-release@v3
         with:
-          fail_on_unmatched_files: false
           files: |
             dist/executables/*.AppImage

--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
 # Light Matter
 
-A simple image viewer with HDR photo support for Windows (support for Linux and macOS is coming soon).
+A simple image viewer with HDR photo support for Windows and Linux (macOS support is coming soon).
 
 <a href="https://apps.microsoft.com/detail/9P96SPR78HM8"><img src="https://get.microsoft.com/images/en-us%20dark.svg" width="200"/></a>
 
 ## Installation
 
-The preferred way to install Light Matter is from [Microsoft Store](https://apps.microsoft.com/detail/9P96SPR78HM8).
+The preferred way to install Light Matter on Windows is from [Microsoft Store](https://apps.microsoft.com/detail/9P96SPR78HM8).
 
 You can alternatively download an unsigned EXE installer from [GitHub Release](https://github.com/Auxx/light-matter/releases) page.
 
-![Light Matter screenshot](https://store-images.s-microsoft.com/image/apps.27459.14077974629932777.28e00b08-4914-4eb2-bfa9-45f69bc6dc32.1b5bf212-4309-4e31-aad9-c655a975aca6 "Light Matter screenshot")
+### Linux
+
+Download the latest `LightMatter-*.AppImage` from the [GitHub Release](https://github.com/Auxx/light-matter/releases) page, make it executable, and run it:
+
+```bash
+chmod +x LightMatter-*.AppImage
+./LightMatter-*.AppImage
+```
 
 ## Features
 

--- a/apps/desktop/src/app/app.ts
+++ b/apps/desktop/src/app/app.ts
@@ -80,7 +80,7 @@ export default class App {
       height: height,
       show: false,
       title: 'Light Matter',
-      icon: '/assets/icon.ico',
+      icon: join(__dirname, 'assets', process.platform === 'win32' ? 'icon.ico' : 'icon.png'),
       webPreferences: {
         contextIsolation: true,
         backgroundThrottling: false,
@@ -146,6 +146,11 @@ export default class App {
 
     App.BrowserWindow = browserWindow;
     App.application = app;
+
+    if (process.platform === 'linux') {
+      // Must match the AppImage's light-matter.desktop filename for KDE/Wayland icon lookup.
+      App.application.commandLine.appendSwitch('class', 'light-matter');
+    }
 
     App.application.setPath('userData', join(App.application.getPath('appData'), 'light-matter'));
     App.startupConfig = new StartupConfig(app);

--- a/apps/desktop/src/app/options/maker-linux.options.json
+++ b/apps/desktop/src/app/options/maker-linux.options.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../../../../../node_modules/nx-electron/src/validation/maker.schema.json",
+  "productName": "Light Matter",
+  "fileAssociations": [
+    { "ext": "jpg", "role": "Viewer" },
+    { "ext": "jpeg", "role": "Viewer" },
+    { "ext": "jxl", "role": "Viewer" },
+    { "ext": "png", "role": "Viewer" },
+    { "ext": "gif", "role": "Viewer" },
+    { "ext": "svg", "role": "Viewer" },
+    { "ext": "webp", "role": "Viewer" },
+    { "ext": "avif", "role": "Viewer" },
+    { "ext": "bmp", "role": "Viewer" }
+  ],
+  "linux": {
+    "target": "appimage",
+    "category": "Graphics",
+    "icon": "./apps/desktop/src/assets/icon.png",
+    "maintainer": "hexmode.org"
+  },
+  "appImage": {
+    "artifactName": "LightMatter-${version}.${ext}"
+  },
+  "electronLanguages": [
+    "en-GB"
+  ]
+}

--- a/apps/desktop/src/app/options/maker-linux.options.json
+++ b/apps/desktop/src/app/options/maker-linux.options.json
@@ -14,9 +14,15 @@
   ],
   "linux": {
     "target": "appimage",
+    "executableName": "light-matter",
     "category": "Graphics",
     "icon": "./apps/desktop/src/assets/icon.png",
-    "maintainer": "hexmode.org"
+    "maintainer": "hexmode.org",
+    "desktop": {
+      "entry": {
+        "StartupWMClass": "light-matter"
+      }
+    }
   },
   "appImage": {
     "artifactName": "LightMatter-${version}.${ext}"

--- a/apps/desktop/src/cache-manager/cache-manager.ts
+++ b/apps/desktop/src/cache-manager/cache-manager.ts
@@ -1,5 +1,6 @@
 import { app } from 'electron';
 import { nanoid } from 'nanoid/non-secure';
+import { mkdirSync } from 'node:fs';
 import { copyFile, mkdir, readdir, rm, stat } from 'node:fs/promises';
 import { dirname, extname, join } from 'node:path';
 import { DatabaseSync, SQLOutputValue } from 'node:sqlite';
@@ -21,9 +22,12 @@ export class CacheManager {
 
   private readonly cacheDir = join(this.userData, 'image-cache');
 
-  private readonly db = new DatabaseSync(this.cacheConfigFile);
+  private readonly db: DatabaseSync;
 
   constructor() {
+    // SQLite does not create its parent directory, unlike the image cache below.
+    mkdirSync(this.userData, { recursive: true });
+    this.db = new DatabaseSync(this.cacheConfigFile);
     this.init();
   }
 

--- a/apps/desktop/src/process-manager/process-manager.ts
+++ b/apps/desktop/src/process-manager/process-manager.ts
@@ -23,19 +23,29 @@ export class ProcessManager {
   readonly argv = async () => yargs(hideBin(process.argv)).parse();
 
   @IpcHandler({ name: 'ProcessManager.getSystemPaths' })
-  readonly getSystemPaths = async (): Promise<SystemPathMapping> => ({
-    home: App.application.getPath('home'),
-    appData: App.application.getPath('appData'),
-    userData: App.application.getPath('userData'),
-    temp: App.application.getPath('temp'),
-    exe: App.application.getPath('exe'),
-    desktop: App.application.getPath('desktop'),
-    documents: App.application.getPath('documents'),
-    downloads: App.application.getPath('downloads'),
-    music: App.application.getPath('music'),
-    pictures: App.application.getPath('pictures'),
-    videos: App.application.getPath('videos'),
-    recent: App.application.getPath('recent'),
-    appConfig: App.startupConfig.configPath()
-  });
+  readonly getSystemPaths = async (): Promise<SystemPathMapping> => {
+    const getPath = (name: Parameters<typeof app.getPath>[0]): string => {
+      try {
+        return App.application.getPath(name);
+      } catch (_) {
+        return '';
+      }
+    };
+
+    return {
+      home: getPath('home'),
+      appData: getPath('appData'),
+      userData: getPath('userData'),
+      temp: getPath('temp'),
+      exe: getPath('exe'),
+      desktop: getPath('desktop'),
+      documents: getPath('documents'),
+      downloads: getPath('downloads'),
+      music: getPath('music'),
+      pictures: getPath('pictures'),
+      videos: getPath('videos'),
+      recent: getPath('recent'),
+      appConfig: App.startupConfig.configPath()
+    };
+  };
 }

--- a/apps/desktop/src/startup-config/startup-config.ts
+++ b/apps/desktop/src/startup-config/startup-config.ts
@@ -84,8 +84,10 @@ export class StartupConfig {
       const configPath = this.configPath();
       const result = readFileSync(configPath, 'utf-8');
       return JSON.parse(result);
-    } catch (_) {
-      console.log('ERROR: Startup config file not found');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        console.error('ERROR: Unable to load startup config file', error);
+      }
       return null;
     }
   };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "make:prod": "npm run build:all && nx run desktop:make",
     "make:prod-nsis": "nx run desktop:make",
     "make:prod-appx": "nx run desktop:make --makerOptionsPath=apps/desktop/src/app/options/maker-appx.options.json",
+    "make:prod-appimage": "nx run desktop:make --makerOptionsPath=apps/desktop/src/app/options/maker-linux.options.json",
     "postinstall": "electron-builder install-app-deps",
     "nxe:build:frontend": "nx build web",
     "nxe:build:backend": "nx build desktop",


### PR DESCRIPTION
Added support for Linux (via AppImage) and fixed the bug producing an error on first launch due to the DB folder not existing: https://github.com/Auxx/light-matter/issues/60

AppImage confirmed working (including HDR) on Fedora 43 with KDE 6.6.4.